### PR TITLE
feat(configurable title assertions): adds option to configure domain name title should end with

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Name          | Type     | Default  | Required | Description
 Name       | Type      | Default | Required | Description
 ---------- | --------- | ------- | -------- | -----------
 **`meta`** | `Boolean` | `false` | `✖️`      | check page meta
-**`titleConstant`** | `String` | `TELUS.com` | `✖️`      | configurable domain name for <title> assertions
+**`titleRegExp`** | `RegExp` | `/.* - TELUS.com/` | `✖️`      | configurable regex for <title> assertions
 
 ## SEO Rules
 
@@ -83,8 +83,7 @@ This is a work in progress, checklist below indicates what has been implemented 
 
 - `<title>`
   - [x] element should exists and be unique
-  - [x] element should end with company domain name (`TELUS.com`) or `titleConstant`
-  - [x] element should use a spaced dash (` - `) to separate sections
+  - [x] element should conform to pattern (` - TELUS.com`)
   - [x] element content length should be not exceed `65` characters
 
 - `<meta name="description">`

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Name          | Type     | Default  | Required | Description
 Name       | Type      | Default | Required | Description
 ---------- | --------- | ------- | -------- | -----------
 **`meta`** | `Boolean` | `false` | `✖️`      | check page meta
+**`titleConstant`** | `String` | `TELUS.com` | `✖️`      | configurable domain name for <title> assertions
 
 ## SEO Rules
 
@@ -82,7 +83,7 @@ This is a work in progress, checklist below indicates what has been implemented 
 
 - `<title>`
   - [x] element should exists and be unique
-  - [x] element should contain company domain name (`TELUS.com`)
+  - [x] element should end with company domain name (`TELUS.com`) or `titleConstant`
   - [x] element should use a spaced dash (` - `) to separate sections
   - [x] element content length should be not exceed `65` characters
 

--- a/assertions/seo.js
+++ b/assertions/seo.js
@@ -27,7 +27,8 @@ module.exports.assertion = function (context, options) {
 
       this.api.getTitle((value) => {
         // TODO: what's the length for French & other languages?
-        assert.ok(/TELUS.com$/.test(value), '<title/> should contain company domain name (`TELUS.com`)')
+        const titleConstant = options.titleConstant || 'TELUS.com'
+        assert.ok(new RegExp(`${titleConstant}$`).test(value), `<title/> should end with company domain name (${titleConstant})`)
         assert.ok(/ - /.test(value), '<title/> should use a spaced dash (` - `) to separate sections')
         assert.ok(value.length <= 65, '<title/> content length should be not exceed `65` characters')
       })

--- a/assertions/seo.js
+++ b/assertions/seo.js
@@ -1,5 +1,7 @@
 module.exports.assertion = function (context, options) {
-  options = Object.assign({ meta: true }, options)
+  options = Object.assign({ meta: true, titleRegExp: /.* - TELUS.com/ }, options)
+
+  if (!(options.titleRegExp instanceof RegExp)) throw new TypeError('`titleRegExp` should be type RegExp')
 
   this.message = `${context} passes SEO checklist`
   this.value = (result) => result
@@ -27,9 +29,7 @@ module.exports.assertion = function (context, options) {
 
       this.api.getTitle((value) => {
         // TODO: what's the length for French & other languages?
-        const titleConstant = options.titleConstant || 'TELUS.com'
-        assert.ok(new RegExp(`${titleConstant}$`).test(value), `<title/> should end with company domain name (${titleConstant})`)
-        assert.ok(/ - /.test(value), '<title/> should use a spaced dash (` - `) to separate sections')
+        assert.ok(options.titleRegExp.test(value), `<title/> should conform to pattern (${options.titleRegExp})`)
         assert.ok(value.length <= 65, '<title/> content length should be not exceed `65` characters')
       })
 


### PR DESCRIPTION
The About team has been told to end their page titles with ` - About TELUS` so we needed a configuration to change the constant the test is checking for.